### PR TITLE
Feature/running server app

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
@@ -75,7 +75,7 @@ def build_server():
             log.debug("building docker...")
             subprocess.Popen(shlex.split("docker build -t vpn-server ."))
             log.debug("docker build")
-            app.config["service_build"] = True
+            app.config["service_built"] = True
             return "", 204
         else:
             return "Config is not ready: " + str(app.config["config_files"]), 409

--- a/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
@@ -8,7 +8,7 @@ import sys
 from flask import Flask
 from flask import request
 
-log = logging.getLogger('cnsmo.serverapp')
+log = logging.getLogger('cnsmo.vpn.server.app')
 
 
 app = Flask(__name__)
@@ -88,12 +88,13 @@ def start_server():
     try:
         if app.config["service_built"]:
             log.debug("running docker...")
-            subprocess.Popen(shlex.split(
+            output = subprocess.check_output(shlex.split(
                 "docker run --net=host  --privileged -v /dev/net/:/dev/net/ --name server-vpn -d vpn-server"))
-            log.debug("docker run")
+
+            log.debug("docker run. output: " + output)
             app.config["service_running"] = True
             return "", 204
-        return "",  409
+        return "Service is not yet built",  409
     except Exception as e:
         return str(e), 409
 
@@ -106,7 +107,7 @@ def stop_server():
             subprocess.Popen(shlex.split("docker rm -f server-vpn"))
             app.config["service_running"] = False
             return "", 204
-        return "",  409
+        return "Service is not yet running",  409
     except Exception as e:
         return str(e), 409
 

--- a/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
@@ -103,7 +103,7 @@ def stop_server():
     try:
         if app.config["service_running"]:
             subprocess.Popen(shlex.split("docker kill server-vpn"))
-            subprocess.Popen(shlex.split("docker rm server-vpn"))
+            subprocess.Popen(shlex.split("docker rm -f server-vpn"))
             app.config["service_running"] = False
             return "", 204
         return "",  409

--- a/src/test/python/vpn/serverchecker.py
+++ b/src/test/python/vpn/serverchecker.py
@@ -36,18 +36,23 @@ def main():
     print "Sending build request..."
     r = requests.post(url_build)
     print r
-    print "Build response: " + r.text
+    print r.content
     r.raise_for_status()
-    time.sleep(1)
+    time.sleep(3)
+
     print "Sending start request..."
     r = requests.post(url_start)
     print r
-    print "Start response: " + r.text
+    print r.content
+    r.raise_for_status()
+    time.sleep(3)
+
+    print "Sending stop request..."
+    r = requests.post(url_stop)
+    print r
+    print r.content
     r.raise_for_status()
 
-    # time.sleep(60)
-    # r = requests.post(url_stop)
 
-
-if __name__== "__main__":
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This patch introduces small fixes in VPN server app which prevented the server to start and stop correctly.
- When the service is build, it now uses the correct flag to state it. An incorrect one was used before, causing the method starting the service to always fail. 
- When stopping the service, it now forces docker container removal, even if the container is not yet completely stopped. Before this fix, any attempt to remove the container while still running (which happened some times while executing the server_stop method) caused the method to exit with error. 
- Methods depending on the state, now return state information when fail due to incorrect state.
