### PR TITLE
Enable VPN server, client and configurator app to read port from args

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/app/vpn/client.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/client.py
@@ -95,12 +95,12 @@ if __name__ == "__main__":
     host = "127.0.0.1"
     port = 9092
     for opt, arg in opts:
-        if opt == "-w" or "--working-dir":
+        if opt in ("-w", "--working-dir"):
             app.config["UPLOAD_FOLDER"] = arg
         elif opt == "-a":
             host = arg
-        elif opt == "p":
-            port = arg
+        elif opt == "-p":
+            port = int(arg)
 
     prepare_config()
     app.run(host=host, port=port, debug=True)

--- a/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
@@ -219,12 +219,12 @@ if __name__ == "__main__":
 
     for opt, arg in opts:
         print opt, arg
-        if opt == "-w":
+        if opt in ("-w", "--working-dir"):
             working_dir = arg
         elif opt == "-a":
             address = arg
         elif opt == "-p":
-            port = arg
+            port = int(arg)
         elif opt == "-s":
             server_address = arg
         elif opt == "-m":
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     manager = VPNConfigManager(vpn_address, vpn_mask, vpn_port, server_address, working_dir)
     app.config["manager"] = manager
 
-    app.run(host=address, port=int(port), debug=True)
+    app.run(host=address, port=port, debug=True)
 
 
 

--- a/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/server.py
@@ -134,14 +134,14 @@ if __name__ == "__main__":
     opts, _ = getopt.getopt(sys.argv[1:], "a:p:w:", ["working-dir="])
 
     host = "127.0.0.1"
-    port = 9092
+    port = 9094
     for opt, arg in opts:
-        if opt == "-w" or "--working-dir":
+        if opt in ("-w", "--working-dir"):
             working_dir = arg
         elif opt == "-a":
             host = arg
         elif opt == "-p":
-            port = arg
+            port = int(arg)
 
     app.config["UPLOAD_FOLDER"] = working_dir
     prepare_config()


### PR DESCRIPTION
An error when parsing the arguments was preventing the port to be read.
This patch fixes this error and unifies the way parameters are read in these apps.
