### PR TITLE
Feature/client certs with different names

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
@@ -22,7 +22,7 @@ def generate_server_cert():
     return "", 204
 
 
-@app.route("/vpn/configs/certs/client/<client_id>", methods=[POST])
+@app.route("/vpn/configs/certs/client/<client_id>/", methods=[POST])
 def generate_client_cert(client_id):
     manager = app.config["manager"]
     manager.generate_client_certs(client_id)
@@ -54,7 +54,7 @@ def get_server_config():
     return response
 
 
-@app.route("/vpn/configs/client/<client_id>", methods=[GET])
+@app.route("/vpn/configs/client/<client_id>/", methods=[GET])
 def get_client_config(client_id):
     manager = app.config["manager"]
     raw_config = manager.get_client_config()
@@ -72,7 +72,7 @@ def get_ca_cert():
     return response
 
 
-@app.route("/vpn/configs/certs/client/<client_id>", methods=[GET])
+@app.route("/vpn/configs/certs/client/<client_id>/", methods=[GET])
 def get_client_cert(client_id):
     manager = app.config["manager"]
     raw_config = manager.get_client_cert(client_id)
@@ -81,7 +81,7 @@ def get_client_cert(client_id):
     return response
 
 
-@app.route("/vpn/configs/keys/client/<client_id>", methods=[GET])
+@app.route("/vpn/configs/keys/client/<client_id>/", methods=[GET])
 def get_client_key(client_id):
     manager = app.config["manager"]
     raw_config = manager.get_client_key(client_id)

--- a/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
+++ b/src/main/python/net/i2cat/cnsmo/app/vpn/configurator.py
@@ -22,10 +22,10 @@ def generate_server_cert():
     return "", 204
 
 
-@app.route("/vpn/configs/certs/client/", methods=[POST])
-def generate_client_cert():
+@app.route("/vpn/configs/certs/client/<client_id>", methods=[POST])
+def generate_client_cert(client_id):
     manager = app.config["manager"]
-    manager.generate_client_certs()
+    manager.generate_client_certs(client_id)
     return "", 204
 
 
@@ -54,8 +54,8 @@ def get_server_config():
     return response
 
 
-@app.route("/vpn/configs/client/", methods=[GET])
-def get_client_config():
+@app.route("/vpn/configs/client/<client_id>", methods=[GET])
+def get_client_config(client_id):
     manager = app.config["manager"]
     raw_config = manager.get_client_config()
     response = make_response(raw_config)
@@ -72,19 +72,19 @@ def get_ca_cert():
     return response
 
 
-@app.route("/vpn/configs/certs/client/", methods=[GET])
-def get_client_cert():
+@app.route("/vpn/configs/certs/client/<client_id>", methods=[GET])
+def get_client_cert(client_id):
     manager = app.config["manager"]
-    raw_config = manager.get_client_cert()
+    raw_config = manager.get_client_cert(client_id)
     response = make_response(raw_config)
     response.headers["Content-Disposition"] = "attachment; filename=client.crt"
     return response
 
 
-@app.route("/vpn/configs/keys/client/", methods=[GET])
-def get_client_key():
+@app.route("/vpn/configs/keys/client/<client_id>", methods=[GET])
+def get_client_key(client_id):
     manager = app.config["manager"]
-    raw_config = manager.get_client_key()
+    raw_config = manager.get_client_key(client_id)
     response = make_response(raw_config)
     response.headers["Content-Disposition"] = "attachment; filename=client.key"
     return response
@@ -121,22 +121,22 @@ class VPNConfigManager:
         command = "sh %s../gen_ca.sh" % self.key_dir
         subprocess.check_call(shlex.split(command), shell=False)
 
-    def generate_client_certs(self):
-        command = "sh %s../gen_client.sh" % self.key_dir
+    def generate_client_certs(self, client_id):
+        command = "sh %s../gen_client.sh -u %s" % (self.key_dir, client_id)
         subprocess.check_call(shlex.split(command))
 
     def generate_server_certs(self):
         command = "sh %s../gen_server.sh" % self.key_dir
         subprocess.check_call(shlex.split(command))
 
-    def get_client_cert(self):
-        f = open(self.key_dir + "client.crt")
+    def get_client_cert(self, client_id):
+        f = open(self.key_dir + "%s.crt" % client_id)
         content = f.read()
         f.close()
         return content
 
-    def get_client_key(self):
-        f = open(self.key_dir + "client.key")
+    def get_client_key(self, client_id):
+        f = open(self.key_dir + "%s.key" % client_id)
         content = f.read()
         f.close()
         return content

--- a/src/main/python/net/i2cat/cnsmo/manager/vpn.py
+++ b/src/main/python/net/i2cat/cnsmo/manager/vpn.py
@@ -119,10 +119,10 @@ class VPNManager:
             client_id = "client-" + str(i)
 
             print "generating vpn client configuration..."
-            self.__configuration_manager.generate_client_cert((client_id, None))
-            client_key = self.__configuration_manager.get_client_key((client_id, None)).content
-            client_crt = self.__configuration_manager.get_client_cert((client_id, None)).content
-            client_conf = self.__configuration_manager.get_client_config((client_id, None)).content
+            self.__configuration_manager.generate_client_cert(client_id, None)
+            client_key = self.__configuration_manager.get_client_key(client_id).content
+            client_crt = self.__configuration_manager.get_client_cert(client_id).content
+            client_conf = self.__configuration_manager.get_client_config(client_id).content
 
             self.__configure_and_start_vpn_client(client_service, client_id, ca_crt, client_key, client_crt, client_conf)
             i += 1

--- a/src/main/python/net/i2cat/cnsmo/manager/vpn.py
+++ b/src/main/python/net/i2cat/cnsmo/manager/vpn.py
@@ -115,14 +115,16 @@ class VPNManager:
         # Generate client config, get it and configure the client service
         i = 0
         for client_service in self.__client_services:
-            print "generating vpn client configuration..."
-            self.__configuration_manager.generate_client_cert(None)
-            client_key = self.__configuration_manager.get_client_key(None).content
-            client_crt = self.__configuration_manager.get_client_cert(None).content
-            client_conf = self.__configuration_manager.get_client_config(None).content
-
             # TODO find a proper name for each client
-            self.__configure_and_start_vpn_client(client_service, "client-" + str(i), ca_crt, client_key, client_crt, client_conf)
+            client_id = "client-" + str(i)
+
+            print "generating vpn client configuration..."
+            self.__configuration_manager.generate_client_cert((client_id, None))
+            client_key = self.__configuration_manager.get_client_key((client_id, None)).content
+            client_crt = self.__configuration_manager.get_client_cert((client_id, None)).content
+            client_conf = self.__configuration_manager.get_client_config((client_id, None)).content
+
+            self.__configure_and_start_vpn_client(client_service, client_id, ca_crt, client_key, client_crt, client_conf)
             i += 1
 
         print "VPN deployed."

--- a/src/main/python/net/i2cat/cnsmo/run/configurator.py
+++ b/src/main/python/net/i2cat/cnsmo/run/configurator.py
@@ -19,14 +19,14 @@ def get_app_request(host, port, service_id, vpn_server_address, vpn_server_port,
              dependencies=[],
              endpoints=[{"uri":"http://%s:%s/vpn/configs/dh/" %(host, port), "driver":"REST", "logic":"get", "name":"get_dh"},
                         {"uri":"http://%s:%s/vpn/configs/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_config"},
-                        {"uri":"http://%s:%s/vpn/configs/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_config"},
+                        {"uri":"http://%s:%s/vpn/configs/client/{param}/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_config"},
                         {"uri":"http://%s:%s/vpn/configs/certs/ca/" %(host, port), "driver":"REST", "logic":"get", "name":"get_ca_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/keys/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_key"},
+                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_cert"},
+                        {"uri":"http://%s:%s/vpn/configs/keys/client/{param}/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_key"},
                         {"uri":"http://%s:%s/vpn/configs/certs/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_cert"},
                         {"uri":"http://%s:%s/vpn/configs/keys/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_key"},
                         {"uri":"http://%s:%s/vpn/configs/certs/ca/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_ca_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}" %(host, port), "driver":"REST", "logic":"post", "name":"generate_client_cert"},
+                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_client_cert"},
                         {"uri":"http://%s:%s/vpn/configs/certs/server/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_server_cert"},])
     return d
 

--- a/src/main/python/net/i2cat/cnsmo/run/configurator.py
+++ b/src/main/python/net/i2cat/cnsmo/run/configurator.py
@@ -19,14 +19,14 @@ def get_app_request(host, port, service_id, vpn_server_address, vpn_server_port,
              dependencies=[],
              endpoints=[{"uri":"http://%s:%s/vpn/configs/dh/" %(host, port), "driver":"REST", "logic":"get", "name":"get_dh"},
                         {"uri":"http://%s:%s/vpn/configs/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_config"},
-                        {"uri":"http://%s:%s/vpn/configs/client/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_config"},
+                        {"uri":"http://%s:%s/vpn/configs/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_config"},
                         {"uri":"http://%s:%s/vpn/configs/certs/ca/" %(host, port), "driver":"REST", "logic":"get", "name":"get_ca_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/certs/client/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/keys/client/" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_key"},
+                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_cert"},
+                        {"uri":"http://%s:%s/vpn/configs/keys/client/{param}" %(host, port), "driver":"REST", "logic":"get", "name":"get_client_key"},
                         {"uri":"http://%s:%s/vpn/configs/certs/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_cert"},
                         {"uri":"http://%s:%s/vpn/configs/keys/server/" %(host, port), "driver":"REST", "logic":"get", "name":"get_server_key"},
                         {"uri":"http://%s:%s/vpn/configs/certs/ca/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_ca_cert"},
-                        {"uri":"http://%s:%s/vpn/configs/certs/client/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_client_cert"},
+                        {"uri":"http://%s:%s/vpn/configs/certs/client/{param}" %(host, port), "driver":"REST", "logic":"post", "name":"generate_client_cert"},
                         {"uri":"http://%s:%s/vpn/configs/certs/server/" %(host, port), "driver":"REST", "logic":"post", "name":"generate_server_cert"},])
     return d
 

--- a/src/test/python/mock/configuratorserver.py
+++ b/src/test/python/mock/configuratorserver.py
@@ -15,9 +15,9 @@ def generate_server_cert():
     return "ServerCert", 200
 
 
-@app.route("/vpn/configs/certs/client/", methods=[POST])
-def generate_client_cert():
-    return "ClientCert", 200
+@app.route("/vpn/configs/certs/client/<client_id>/", methods=[POST])
+def generate_client_cert(client_id):
+    return "ClientCert " + client_id, 200
 
 
 @app.route("/vpn/configs/certs/ca/", methods=[POST])
@@ -35,9 +35,9 @@ def get_server_config():
     return "GotServerConfig", 200
 
 
-@app.route("/vpn/configs/client/", methods=[GET])
-def get_client_config():
-    return "GotClientConfig", 200
+@app.route("/vpn/configs/client/<client_id>/", methods=[GET])
+def get_client_config(client_id):
+    return "GotClientConfig " + client_id, 200
 
 
 @app.route("/vpn/configs/certs/ca/", methods=[GET])
@@ -45,14 +45,14 @@ def get_ca_cert():
     return "GotCACert", 200
 
 
-@app.route("/vpn/configs/certs/client/", methods=[GET])
-def get_client_cert():
-    return "GotClientCert", 200
+@app.route("/vpn/configs/certs/client/<client_id>/", methods=[GET])
+def get_client_cert(client_id):
+    return "GotClientCert " + client_id, 200
 
 
-@app.route("/vpn/configs/keys/client/", methods=[GET])
-def get_client_key():
-    return "GotClientKey", 200
+@app.route("/vpn/configs/keys/client/<client_id>/", methods=[GET])
+def get_client_key(client_id):
+    return "GotClientKey " + client_id, 200
 
 
 @app.route("/vpn/configs/certs/server/", methods=[GET])

--- a/src/test/python/vpn/vpnmanagertest.py
+++ b/src/test/python/vpn/vpnmanagertest.py
@@ -14,7 +14,7 @@ if not src_dir in sys.path:
 from src.main.python.net.i2cat.cnsmo.deployment.bash import BashDeployer
 from src.main.python.net.i2cat.cnsmo.manager.cnsmo import CNSMOManager
 from src.main.python.net.i2cat.cnsmo.manager.vpn import VPNManager
-from main.python.net.i2cat.factory.system.state.factory import SystemStateFactory
+from src.main.python.net.i2cat.factory.system.state.factory import SystemStateFactory
 
 
 class ConfiguratorServiceTest(unittest.TestCase):
@@ -113,13 +113,17 @@ class ConfiguratorServiceTest(unittest.TestCase):
         self.assertTrue(os.path.exists("/home/CNSMO/ENVS/VPNServerService-234/server.py"))
 
         print "Testing Client 1"
+        client_id = "Client1"
+        client_config_generated = configurator.generate_client_cert(client_id, None).content
+        self.assertEquals("ClientCert " + client_id, client_config_generated)
 
-        client_config_generated = configurator.generate_client_cert(None)
-        client_cert_generated = configurator.generate_client_cert(None)
+        client_cert = configurator.get_client_cert(client_id, None).content
+        client_key = configurator.get_client_key(client_id, None).content
+        client_config = configurator.get_client_config(client_id, None).content
 
-        client_cert = configurator.get_client_cert(None).content
-        client_key = configurator.get_client_key(None).content
-        client_config = configurator.get_client_config(None).content
+        self.assertEquals("GotClientKey " + client_id, client_key)
+        self.assertEquals("GotClientCert " + client_id, client_cert)
+        self.assertEquals("GotClientConfig " + client_id, client_config)
 
         client_1.set_ca_cert({"file":("test", ca)})
         client_1.set_config({"file":("test", client_config)})
@@ -134,13 +138,17 @@ class ConfiguratorServiceTest(unittest.TestCase):
 
 
         print "Testing Client 2"
+        client_id = "Client2"
+        client_config_generated = configurator.generate_client_cert(client_id, None).content
+        self.assertEquals("ClientCert " + client_id, client_config_generated)
 
-        client_config_generated = configurator.generate_client_cert(None)
-        client_cert_generated = configurator.generate_client_cert(None)
+        client_cert = configurator.get_client_cert(client_id, None).content
+        client_key = configurator.get_client_key(client_id, None).content
+        client_config = configurator.get_client_config(client_id, None).content
 
-        client_cert = configurator.get_client_cert(None).content
-        client_key = configurator.get_client_key(None).content
-        client_config = configurator.get_client_config(None).content
+        self.assertEquals("GotClientKey " + client_id, client_key)
+        self.assertEquals("GotClientCert " + client_id, client_cert)
+        self.assertEquals("GotClientConfig " + client_id, client_config)
 
         client_2.set_ca_cert({"file":("test", ca)})
         client_2.set_config({"file":("test", client_config)})
@@ -222,14 +230,14 @@ class ConfiguratorServiceTest(unittest.TestCase):
                  dependencies=[],
                  endpoints=[{"uri":"http://127.0.0.1:9093/vpn/configs/dh/", "driver":"REST", "logic":"get", "name":"get_dh"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/server/", "driver":"REST", "logic":"get", "name":"get_server_config"},
-                            {"uri":"http://127.0.0.1:9093/vpn/configs/client/", "driver":"REST", "logic":"get", "name":"get_client_config"},
+                            {"uri":"http://127.0.0.1:9093/vpn/configs/client/{param}/", "driver":"REST", "logic":"get", "name":"get_client_config"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/certs/ca/", "driver":"REST", "logic":"get", "name":"get_ca_cert"},
-                            {"uri":"http://127.0.0.1:9093/vpn/configs/certs/client/", "driver":"REST", "logic":"get", "name":"get_client_cert"},
-                            {"uri":"http://127.0.0.1:9093/vpn/configs/keys/client/", "driver":"REST", "logic":"get", "name":"get_client_key"},
+                            {"uri":"http://127.0.0.1:9093/vpn/configs/certs/client/{param}/", "driver":"REST", "logic":"get", "name":"get_client_cert"},
+                            {"uri":"http://127.0.0.1:9093/vpn/configs/keys/client/{param}/", "driver":"REST", "logic":"get", "name":"get_client_key"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/certs/server/", "driver":"REST", "logic":"get", "name":"get_server_cert"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/keys/server/", "driver":"REST", "logic":"get", "name":"get_server_key"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/certs/ca/", "driver":"REST", "logic":"post", "name":"generate_ca_cert"},
-                            {"uri":"http://127.0.0.1:9093/vpn/configs/certs/client/", "driver":"REST", "logic":"post", "name":"generate_client_cert"},
+                            {"uri":"http://127.0.0.1:9093/vpn/configs/certs/client/{param}/", "driver":"REST", "logic":"post", "name":"generate_client_cert"},
                             {"uri":"http://127.0.0.1:9093/vpn/configs/certs/server/", "driver":"REST", "logic":"post", "name":"generate_server_cert"},])
         return d
 

--- a/src/test/python/vpn/vpnmanagertest.py
+++ b/src/test/python/vpn/vpnmanagertest.py
@@ -113,13 +113,13 @@ class ConfiguratorServiceTest(unittest.TestCase):
         self.assertTrue(os.path.exists("/home/CNSMO/ENVS/VPNServerService-234/server.py"))
 
         print "Testing Client 1"
-        client_id = "Client1"
+        client_id = "Client-1"
         client_config_generated = configurator.generate_client_cert(client_id, None).content
         self.assertEquals("ClientCert " + client_id, client_config_generated)
 
-        client_cert = configurator.get_client_cert(client_id, None).content
-        client_key = configurator.get_client_key(client_id, None).content
-        client_config = configurator.get_client_config(client_id, None).content
+        client_cert = configurator.get_client_cert(client_id).content
+        client_key = configurator.get_client_key(client_id).content
+        client_config = configurator.get_client_config(client_id).content
 
         self.assertEquals("GotClientKey " + client_id, client_key)
         self.assertEquals("GotClientCert " + client_id, client_cert)
@@ -138,13 +138,13 @@ class ConfiguratorServiceTest(unittest.TestCase):
 
 
         print "Testing Client 2"
-        client_id = "Client2"
+        client_id = "Client-2"
         client_config_generated = configurator.generate_client_cert(client_id, None).content
         self.assertEquals("ClientCert " + client_id, client_config_generated)
 
-        client_cert = configurator.get_client_cert(client_id, None).content
-        client_key = configurator.get_client_key(client_id, None).content
-        client_config = configurator.get_client_config(client_id, None).content
+        client_cert = configurator.get_client_cert(client_id).content
+        client_key = configurator.get_client_key(client_id).content
+        client_config = configurator.get_client_config(client_id).content
 
         self.assertEquals("GotClientKey " + client_id, client_key)
         self.assertEquals("GotClientCert " + client_id, client_cert)


### PR DESCRIPTION
Generate client certificates with different names.

Different names must be used for each client, to avoid an error in the client keys data base used by easy-rsa.

In order to allow this feature, configurator server endpoints related to clients now accept a url parameter with the client_id.
The vpn manager makes use of these endpoints when deploying the VPN, passing them a different client_id for each client.
