### PR TITLE
Fix/remove hardcoded cwd

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fw-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fw-deployment.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-python /tmp/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fw-deployment.py &
+cwd=${PWD}
+python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fw-deployment.py &
 disown $!
 ss-get --timeout=1800 net.i2cat.cnsmo.service.fw.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-python /tmp/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
+cwd=${PWD}
+python ${cmd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
 disown $!
 ss-get --timeout=1800 VPN_server.1:net.i2cat.cnsmo.service.vpn.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
-python /tmp/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py &
+cwd=${PWD}
+python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py &
 disown $!
 ss-get --timeout=1800 net.i2cat.cnsmo.service.vpn.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-postinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-postinstall.sh
@@ -15,10 +15,12 @@ cd ..
 # install cnsmo requirements
 sudo pip install -r cnsmo/cnsmo/requirements.txt
 
+
 #build new-easy-rsa docker
-cd /tmp/cnsmo/cnsmo-net-services/src/main/docker/vpn/easy-rsa
+cwd=${PWD}
+cd ${cwd}/cnsmo/cnsmo-net-services/src/main/docker/vpn/easy-rsa
 docker build -t new-easy-rsa .
-cd /tmp
+cd ${cwd}
 
 #install redis
 wget http://download.redis.io/releases/redis-3.0.7.tar.gz


### PR DESCRIPTION
This patch updates deployment script so they work whatever current working directory (CWD) is (assuming write permission is given :) )

Previously it was assumed (hardcoded) that CWD was /tmp. However, due to a recent change in SlipStream, it is no longer this way (it is now /var/lib/slipstream), which caused previously working systems not being correctly deployed.

This patch causes deployment scripts to get CWD by means of the os lib in python, and by means of hte PWD variable in bash.
