### PR TITLE
Fix/remove hardcoded cwd

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 cwd=${PWD}
-python ${cmd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
+python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
 disown $!
 ss-get --timeout=1800 VPN_server.1:net.i2cat.cnsmo.service.vpn.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
@@ -173,17 +173,7 @@ def logToFile(message, filename, filemode):
 def ss_getinstances():
     # ss:groups  cyclone-fr2:VPN,cyclone-fr1:client2,cyclone-fr2:client1
 
-    # FIXME: "ss-get ss:groups" does not currently work.
-    #        Corresponding bug issue: https://github.com/slipstream/SlipStreamServer/issues/627
-    # groups = call("ss-get ss:groups")
-
-    # NOTE: This is a workaround for the previous bug in order to GET the groups.
-    call('touch /tmp/slipstream.client.conf')
-    ch = ConfigHolder()
-    ssc = SlipStreamHttpClient(ch)
-    ssc._retrieveAndSetRun()
-    groups = ssc.run_dom.attrib.get('groups')
-
+    groups = call("ss-get ss:groups")
     cloud_node_pairs = groups.split(",")
 
     nodes = list()


### PR DESCRIPTION
Workaround to get ss:groups is failing with new directory usage of SlipStream.
It fails to locate a configuration file.

As the error that originated the workaround has already been solved,
this patch replaces the failing workaround with the proper way to get ss:groups, that is,
a direct call to ss-get ss:groups
