### PR TITLE
Feature/vpn announces ip address

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -78,6 +78,9 @@ def main():
     logToFile("VPN using interface %s with ipaddr %s and ipv6addr %s" %
               (vpn_iface, vpn_local_ipv4_address, vpn_local_ipv6_address), log_file, "a")
 
+    call("ss-set vpn.address %s" % vpn_local_ipv4_address)
+    call("ss-set vpn.address6 %s" % vpn_local_ipv6_address)
+
     call("ss-display \"VPN: VPN has been established! Using interface %s with ipaddr %s and ipv6addr %s\"" %
          (vpn_iface, vpn_local_ipv4_address, vpn_local_ipv6_address))
     print "VPN deployed!"
@@ -94,6 +97,7 @@ def getCurrentInterfaces():
 
 def getInterfaceIPv4Address(iface):
     return call("ifconfig " + iface + " | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'").rstrip('\n')
+
 
 def getInterfaceIPv6Address(iface):
     return call("ifconfig " + iface + " | grep 'inet6 addr:' | cut -d: -f2 | awk '{ print $1}'").rstrip('\n')

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -60,6 +60,8 @@ def main():
     call('ss-display \"VPN: Waiting for VPN to be established...\"')
     call("ss-get --timeout=1800 %s:net.i2cat.cnsmo.service.vpn.ready" % server_instance_id)
 
+    time.sleep(5)
+
     date = call('date')
     logToFile("VPN deployed at %s" % date, log_file, "a")
 

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -100,7 +100,7 @@ def getInterfaceIPv4Address(iface):
 
 
 def getInterfaceIPv6Address(iface):
-    return call("ifconfig " + iface + " | grep 'inet6 addr:' | cut -d: -f2 | awk '{ print $1}'").rstrip('\n')
+    return call("ifconfig " + iface + "| awk '/inet6 / { print $3 }'").rstrip('\n')
 
 
 def logToFile(message, filename, filemode):

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -70,7 +70,7 @@ def main():
             vpn_iface = current_iface
 
     if not vpn_iface:
-        call('ss-abort \"Failed to create tap interface, required for the VPN\"')
+        call("ss-abort \"%s:Failed to create tap interface, required for the VPN\"" % instance_id)
         return
 
     vpn_local_ipv4_address = getInterfaceIPv4Address(vpn_iface)


### PR DESCRIPTION
This patch causes VPN service to announce VPN enabled interfaces' addresses by means of SlipStream output parameters.

New parameters:
- vpn.address output parameter is now used to hold VPN enabled interface IPv4 address
- vpn.address6 output parameter is now used to hold VPN enabled interface IPv6 address

This patch retrieves the addresses by parsing output from ifconfig and /sys/class/net.
