### PR TITLE
Fix/service maker json bug

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/service/maker.py
+++ b/src/main/python/net/i2cat/cnsmo/service/maker.py
@@ -80,7 +80,7 @@ class ServiceMaker:
             if logic == "post":
                 func = lambda x : lib(url=clean_uri, json=x)
 
-            if logic == "upload":
+            elif logic == "upload":
                 func = lambda x : lib(url=clean_uri, files=x)
 
             else:

--- a/src/test/python/cnsmo/service/maker.py
+++ b/src/test/python/cnsmo/service/maker.py
@@ -1,0 +1,121 @@
+import json
+
+import sys
+
+import time
+
+import os
+import requests
+import unittest
+
+from multiprocessing import Process
+
+path = os.path.dirname(os.path.abspath(__file__))
+src_dir = path + "/../../../../../"
+if src_dir not in sys.path:
+    sys.path.append(src_dir)
+
+from src.main.python.net.i2cat.cnsmo.service.maker import ServiceMaker
+from src.test.python.cnsmo.service.testapp import TestApp
+
+
+class ServiceMakerTest(unittest.TestCase):
+
+    def setUp(self):
+
+        # given this app
+        test_app = TestApp('127.0.0.1', 9090)
+        self.server = Process(target=test_app.launch_app)
+        self.server.start()
+
+        # with these uris
+        self.url_basic = "http://127.0.0.1:9090/sample/basic/"
+        self.url_params = "http://127.0.0.1:9090/sample/params/{}/{}/"
+        self.url_json = "http://127.0.0.1:9090/sample/json/"
+        self.url_params_json = "http://127.0.0.1:9090/sample/params/json/{}/{}/"
+        self.url_file = "http://127.0.0.1:9090/sample/file/"
+
+        # and generated service client for that app
+        self.service = ServiceMaker().make_service("Sample", test_app.get_app_request("Sample").get('endpoints'))
+
+        # and these sample values
+        self.sample_params = {'param1': 'abc', 'param2': 'def'}
+        self.sample_json = {'a': 'abc', 'b': 'def', 'c': ['ccc', 'ddd']}
+        self.sample_file = "THIS IS A SAMPLE FILE \n"
+
+        time.sleep(1)
+
+    def tearDown(self):
+        self.server.terminate()
+        self.server.join()
+
+    def test_expected_behaviour_with_requests(self):
+
+        sample_params = self.sample_params
+        sample_json = self.sample_json
+        sample_file = self.sample_file
+
+        print("SAMPLES:")
+        print(sample_params)
+        print(sample_json)
+        print(sample_file)
+
+        print("OUTPUTS:")
+        r = requests.get(self.url_basic)
+        r.raise_for_status()
+
+        r = requests.get(self.url_params.format(sample_params.get('param1'), sample_params.get('param2')))
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_params, sort_keys=True), json.dumps(json.loads(r.content), sort_keys=True))
+
+        r = requests.get(self.url_json, json=sample_json)
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_json, sort_keys=True), json.dumps(json.loads(r.content), sort_keys=True))
+
+        r = requests.get(self.url_params_json.format(sample_params.get('param1'), sample_params.get('param2')),
+                         json=sample_json)
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_json, sort_keys=True),
+                         json.dumps(json.loads(r.content).get('input_json'), sort_keys=True))
+        self.assertEqual(json.dumps(sample_params, sort_keys=True),
+                         json.dumps(json.loads(r.content).get('parameters'), sort_keys=True))
+
+        r = requests.post(self.url_basic)
+        r.raise_for_status()
+
+        r = requests.post(self.url_params.format(sample_params.get('param1'), sample_params.get('param2')))
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_params, sort_keys=True), json.dumps(json.loads(r.content), sort_keys=True))
+
+        r = requests.post(self.url_json, json=sample_json)
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_json, sort_keys=True), json.dumps(json.loads(r.content), sort_keys=True))
+
+        r = requests.post(self.url_params_json.format(sample_params.get('param1'), sample_params.get('param2')),
+                          json=sample_json)
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(json.dumps(sample_json, sort_keys=True),
+                         json.dumps(json.loads(r.content).get('input_json'), sort_keys=True))
+        self.assertEqual(json.dumps(sample_params, sort_keys=True),
+                         json.dumps(json.loads(r.content).get('parameters'), sort_keys=True))
+
+        r = requests.post(self.url_file, data={}, files={'file': ('sample.txt', sample_file)})
+        r.raise_for_status()
+        print(r.content)
+        self.assertEqual(sample_file, r.content)
+
+    def test_expected_json_arrives_correctly_in_post_with_json(self):
+
+        r = self.service.post_with_json(self.sample_json)
+        print(r.content)
+        self.assertEqual(json.dumps(self.sample_json, sort_keys=True), json.dumps(json.loads(r.content), sort_keys=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/python/cnsmo/service/testapp.py
+++ b/src/test/python/cnsmo/service/testapp.py
@@ -1,0 +1,131 @@
+import getopt
+import sys
+
+from flask import Flask
+from flask import make_response
+from flask import jsonify
+from flask import request
+
+app = Flask(__name__)
+
+GET = "GET"
+POST = "POST"
+DELETE = "DELETE"
+
+
+@app.route("/sample/basic/", methods=[GET])
+def get_basic():
+    return "", 204
+
+
+@app.route("/sample/params/<param1>/<param2>/", methods=[GET])
+def get_with_url_params(param1, param2):
+    params_dict = {'param1': param1, 'param2': param2}
+    return jsonify(params_dict)
+
+
+@app.route("/sample/json/", methods=[GET])
+def get_with_json():
+    rcv_json_dict = request.get_json()
+    rcv_json_str = request.data
+    return jsonify(rcv_json_dict)
+
+
+@app.route("/sample/params/json/<param1>/<param2>/", methods=[GET])
+def get_with_url_params_and_json(param1, param2):
+    rcv_json_dict = request.get_json()
+    params_dict = {'param1': param1, 'param2': param2}
+    complete_dict = {'parameters': params_dict, 'input_json': rcv_json_dict}
+    return jsonify(complete_dict)
+
+
+@app.route("/sample/basic/", methods=[POST])
+def post_basic():
+    return "", 204
+
+
+@app.route("/sample/params/<param1>/<param2>/", methods=[POST])
+def post_with_url_params(param1, param2):
+    params_dict = {'param1': param1, 'param2': param2}
+    return jsonify(params_dict)
+
+
+@app.route("/sample/json/", methods=[POST])
+def post_with_json():
+    rcv_json_dict = request.get_json()
+    rcv_json_str = request.data
+    return jsonify(rcv_json_dict)
+
+
+@app.route("/sample/params/json/<param1>/<param2>/", methods=[POST])
+def post_with_url_params_and_json(param1, param2):
+    rcv_json_dict = request.get_json()
+    params_dict = {'param1': param1, 'param2': param2}
+    complete_dict = {'parameters': params_dict, 'input_json': rcv_json_dict}
+    print(complete_dict)
+    return jsonify(complete_dict)
+
+
+@app.route("/sample/file/", methods=[POST])
+def post_with_files():
+    rcv_file = request.files['file']
+    response = make_response(rcv_file.read())
+    response.headers["Content-Disposition"] = "attachment; filename=file.txt"
+    return response
+
+
+class TestApp(object):
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def get_app_request(self, service_id):
+        host = self.host
+        port = self.port
+        d = dict(service_id=service_id,
+                 trigger='python testapp.py -a %s -p %s' % (host, port),
+                 resources=[],
+                 dependencies=[],
+                 endpoints=[{"uri": "http://%s:%s/sample/basic/" % (host, port), "driver": "REST", "logic": "get",
+                             "name": "get_basic"},
+                            {"uri": "http://%s:%s/sample/params/{param}/{param}/" % (host, port), "driver": "REST",
+                             "logic": "get", "name": "get_with_url_params"},
+                            {"uri": "http://%s:%s/sample/json/" % (host, port), "driver": "REST", "logic": "get",
+                             "name": "get_with_json"},
+                            {"uri": "http://%s:%s/sample/params/json/{param}/{param}/" % (host, port), "driver": "REST",
+                             "logic": "get", "name": "get_with_url_params_and_json"},
+
+                            {"uri": "http://%s:%s/sample/basic/" % (host, port), "driver": "REST", "logic": "post",
+                             "name": "post_basic"},
+                            {"uri": "http://%s:%s/sample/params/{param}/{param}/" % (host, port), "driver": "REST",
+                             "logic": "post", "name": "post_with_url_params"},
+                            {"uri": "http://%s:%s/sample/json/" % (host, port), "driver": "REST", "logic": "post",
+                             "name": "post_with_json"},
+                            {"uri": "http://%s:%s/sample/params/json/{param}/{param}/" % (host, port), "driver": "REST",
+                             "logic": "post", "name": "post_with_url_params_and_json"},
+                            {"uri": "http://%s:%s/sample/params/json/{param}/{param}/" % (host, port), "driver": "REST",
+                             "logic": "upload", "name": "post_with_files"}, ])
+        return d
+
+    def launch_app(self):
+        app.run(host=self.host, port=self.port, debug=True)
+
+
+def main(host, port):
+    test_app = TestApp(host, port)
+    test_app.launch_app()
+
+if __name__ == "__main__":
+
+    opts, _ = getopt.getopt(sys.argv[1:], "a:p:", [])
+
+    host = "127.0.0.1"
+    port = 9090
+    for opt, arg in opts:
+        if opt == "-a":
+            host = arg
+        elif opt == "-p":
+            port = int(arg)
+
+    main(host, port)


### PR DESCRIPTION
 Fixes bug in service maker related to post with json requests.

The bug caused json attribute to be ignored in post requests.
The second 'if' clause was evaluated to false, so its 'else' clause
was executed, overriding func to one without json.

With this fix, only one clause is evaluated true, which results in
func being assigned only once. In case of post, assigned to a func
with json argument.
