### PR TITLE
Feature/vpn server id from ss

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -4,6 +4,22 @@
 # This script is meant to be run by SlipStream, using a privileged user
 #
 # All ss-get/ss-set applies to local node variables, unless a node instance_id is prefixed.
+#
+# Requires the following parameters in slipstream application component:
+# Input parameters:
+# vpn.server.instanceid: Indicates the instanceid of the component acting as VPN server
+#
+# Output parameters:
+# net.i2cat.cnsmo.service.vpn.client.listening: Used to communicate the client to be listening for orchestrator orders
+# net.i2cat.cnsmo.service.vpn.client.ready: Used to communicate the client to be configured properly
+# vpn.address: Used to communicate the IPv4 address of this component
+# vpn.address6: Used to communicate the IPv6 address of this component
+#
+# Requires the following output parameters from the VPN server:
+# net.i2cat.cnsmo.core.ready: Used to communicate CNSMO core is ready.
+# net.i2cat.cnsmo.dss.address: Used to communicate CNSMO distributed system state address.
+# net.i2cat.cnsmo.service.vpn.orchestrator.ready: Used to communicate the vpn orchestrator is ready
+# net.i2cat.cnsmo.service.vpn.ready: Used to communicate the VPN service to be configured properly
 ###
 
 import subprocess
@@ -24,8 +40,7 @@ def main():
     log_file = os.getcwd() + "/cnsmo/vpn.log"
     ifaces_prev = getCurrentInterfaces()
 
-    # TODO get this from slipstream context, by inspecting roles each component has
-    server_instance_id = "VPN_server.1"
+    server_instance_id = call('ss-get vpn.server.instanceid').rstrip('\n')
 
     date = call('date')
     logToFile("Waiting for CNSMO at %s" % date, log_file, "w+")

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -7,11 +7,10 @@
 #
 # Requires the following parameters in slipstream application component:
 # Input parameters:
-# vpn.server.instanceid: Indicates the instanceid of the component acting as VPN server
+# vpn.server.nodeinstanceid: Indicates the node.id of the component acting as VPN server
 #
 # Output parameters:
 # net.i2cat.cnsmo.service.vpn.client.listening: Used to communicate the client to be listening for orchestrator orders
-# net.i2cat.cnsmo.service.vpn.client.ready: Used to communicate the client to be configured properly
 # vpn.address: Used to communicate the IPv4 address of this component
 # vpn.address6: Used to communicate the IPv6 address of this component
 #
@@ -40,7 +39,7 @@ def main():
     log_file = os.getcwd() + "/cnsmo/vpn.log"
     ifaces_prev = getCurrentInterfaces()
 
-    server_instance_id = call('ss-get vpn.server.instanceid').rstrip('\n')
+    server_instance_id = call('ss-get vpn.server.nodeinstanceid').rstrip('\n')
 
     date = call('date')
     logToFile("Waiting for CNSMO at %s" % date, log_file, "w+")

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
@@ -3,5 +3,5 @@
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
 disown $!
-serverid=$(ss-get vpn.server.instanceid)
+serverid=$(ss-get vpn.server.nodeinstanceid)
 ss-get --timeout=1800 ${serverid}:net.i2cat.cnsmo.service.vpn.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
@@ -3,4 +3,5 @@
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
 disown $!
-ss-get --timeout=1800 VPN_server.1:net.i2cat.cnsmo.service.vpn.ready
+serverid=$(ss-get vpn.server.instanceid)
+ss-get --timeout=1800 ${serverid}:net.i2cat.cnsmo.service.vpn.ready

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
@@ -69,6 +69,8 @@ def deployvpn():
     log_file = os.getcwd() + "/cnsmo/vpn.log"
     ifaces_prev = getCurrentInterfaces()
 
+    call('ss-set vpn.server.nodeinstanceid %s' % instance_id)
+
     # wait for CNSMO core
     call('ss-get net.i2cat.cnsmo.core.ready')
     redis_address = call("ss-get net.i2cat.cnsmo.dss.address").rstrip('\n')


### PR DESCRIPTION
Use a SlipStrem parameter to tell which of the components acts as a VPN server.

The VPN-client now requires an input parameter (called vpn.server.nodeinstanceid) with the nodename.id of the instance that will act as VPN server.
This was hardcoded to VPN_server.1 in previous version.

The VPN-server now publishes an output parameter (also called vpn.server.nodeinstanceid) announcing it is the one to be used as VPN server.

Application developers can now use any name in their components, given that they map the vpn.server.nodeinstanceid input parameter in VPN-client children nodes to the value of the output parameter in VPN-server child node.

This way, as an application developer you have flexibility in the names to use.
Although you have to specify to clients who is the server.
