### PR TITLE
Avoid unknown key error by aborting execution immediately... 

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -40,6 +40,9 @@ def main():
     ifaces_prev = getCurrentInterfaces()
 
     server_instance_id = call('ss-get --timeout=1200 vpn.server.nodeinstanceid').rstrip('\n')
+    if not server_instance_id:
+        # timeout! Abort the script immediately (ss-get will abort the whole deployment in short time)
+        return
 
     date = call('date')
     logToFile("Waiting for CNSMO at %s" % date, log_file, "w+")

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.sh
@@ -4,4 +4,8 @@ cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py &
 disown $!
 serverid=$(ss-get --timeout=1200 vpn.server.nodeinstanceid)
+# In case of timeout, serverid will not be set. But next ss-get will fail with Unknown key error.
+# Better to finish script immediately (ss-get that got timeout will abort the deployment in short time)
+if ! [[ -z "$serverid" ]]; then
 ss-get --timeout=1800 ${serverid}:net.i2cat.cnsmo.service.vpn.ready
+fi


### PR DESCRIPTION
... after a timeout in ss-get vpn.server.nodeinstanceid
