### PR TITLE
Fix/failed to create tap interface

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-client-deployment.py
@@ -83,14 +83,10 @@ def main():
     logToFile("VPN deployed at %s" % date, log_file, "a")
 
     # assuming the VPN interface (probably tap0) is the only one created during this script execution
-    vpn_iface = None
-    for current_iface in getCurrentInterfaces():
-        if current_iface not in ifaces_prev:
-            vpn_iface = current_iface
-
+    vpn_iface = detect_new_interface_in_30_sec(ifaces_prev)
     if not vpn_iface:
-        call("ss-abort \"%s:Failed to create tap interface, required for the VPN\"" % instance_id)
-        return
+        call("ss-abort \"%s:Timeout! Failed to locate tap interface, created by the VPN\"" % instance_id)
+        return -1
 
     vpn_local_ipv4_address = getInterfaceIPv4Address(vpn_iface)
     vpn_local_ipv6_address = getInterfaceIPv6Address(vpn_iface)
@@ -103,6 +99,24 @@ def main():
     call("ss-display \"VPN: VPN has been established! Using interface %s with ipaddr %s and ipv6addr %s\"" %
          (vpn_iface, vpn_local_ipv4_address, vpn_local_ipv6_address))
     print "VPN deployed!"
+
+
+def detect_new_interface_in_30_sec(ifaces_prev):
+    vpn_iface = do_detect_new_interface(ifaces_prev)
+    attempts = 0
+    while not vpn_iface and attempts < 6:
+        time.sleep(5)
+        vpn_iface = do_detect_new_interface(ifaces_prev)
+        attempts += 1
+    return vpn_iface
+
+
+def do_detect_new_interface(ifaces_prev):
+    vpn_iface = None
+    for current_iface in getCurrentInterfaces():
+        if current_iface not in ifaces_prev:
+            vpn_iface = current_iface
+    return vpn_iface
 
 
 def launchVPNClient(hostname, redis_address, instance_id):

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
@@ -131,9 +131,6 @@ def deployvpn():
 
     time.sleep(5)
 
-    # Communicate that the VPN has been established
-    call('ss-set net.i2cat.cnsmo.service.vpn.ready true')
-
     date = call('date')
     logToFile("VPN deployed at %s" % date, log_file, "a")
 
@@ -150,6 +147,9 @@ def deployvpn():
 
     call("ss-set vpn.address %s" % vpn_local_ipv4_address)
     call("ss-set vpn.address6 %s" % vpn_local_ipv6_address)
+
+    # Communicate that the VPN has been established
+    call('ss-set net.i2cat.cnsmo.service.vpn.ready true')
 
     call("ss-display \"VPN: VPN has been established! Using interface %s with ipaddr %s and ipv6addr %s\"" %
          (vpn_iface, vpn_local_ipv4_address, vpn_local_ipv6_address))

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpn-server-deployment.py
@@ -12,9 +12,6 @@ import sys
 import threading
 import time
 
-from slipstream.ConfigHolder import ConfigHolder
-from slipstream.SlipStreamHttpClient import SlipStreamHttpClient
-
 path = os.path.dirname(os.path.abspath(__file__))
 src_dir = path + "/../../../../../../../../../"
 if src_dir not in sys.path:


### PR DESCRIPTION
This patch:
- retries during 30 seconds before failing.
- communicates the VPN is ready after trying to locate the tap interface
- changes the error description to "Timeout! Failed to locate tap interface, created by the VPN"
