### PR TITLE
Feature/apps bind to all local addresses

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 
     opts, _ = getopt.getopt(sys.argv[1:], "a:p:")
 
-    host = "127.0.0.1"
+    bind_address = "127.0.0.1"
     port = 9095
     for opt, arg in opts:
         if opt == "-a":
@@ -135,4 +135,4 @@ if __name__ == "__main__":
             port = int(arg)
 
     prepare_config()
-    app.run(host=host, port=port, debug=True)
+    app.run(host=bind_address, port=port, debug=True)

--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/server.py
@@ -1,7 +1,9 @@
 def get_server_app_request(host, port, service_id):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
-             trigger='python server.py -a %s -p %s' %(host, port),
+             trigger='python server.py -a %s -p %s' % (bind_address, port),
              resources=["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/fw/Dockerfile",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/fw/sc-manager.py",],

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/configurator.py
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/configurator.py
@@ -14,9 +14,11 @@ from src.main.python.net.i2cat.cnsmo.manager.cnsmo import CNSMOManager
 
 def get_app_request(host, port, service_id, lb_address, lb_port, lb_mode, lb_backend_servers):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
 
-             trigger= 'python configurator.py -a %s -p %s -s %s -t %s -m %s -b %s' %(host, port, lb_address, lb_port, lb_mode, lb_backend_servers),
+             trigger='python configurator.py -a %s -p %s -s %s -t %s -m %s -b %s' % (bind_address, port, lb_address, lb_port, lb_mode, lb_backend_servers),
 
              resources = ["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/lb/app/configurator.py",
                           "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/lb/start.bash",

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/server.py
@@ -14,8 +14,10 @@ from src.main.python.net.i2cat.cnsmo.manager.cnsmo import CNSMOManager
 
 def get_server_app_request(host, port, service_id, lb_port):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
-             trigger='python server.py -a %s -p %s -t %s -w "$(pwd)"' %(host, port, lb_port),
+             trigger='python server.py -a %s -p %s -t %s -w "$(pwd)"' % (bind_address, port, lb_port),
              resources=["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/lb/app/server.py",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/lb/start.bash",],
              dependencies=[],

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/client.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/client.py
@@ -2,8 +2,10 @@
 
 def get_app_request(host, port, service_id):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
-             trigger='python client.py -a %s -p %s -w "$(pwd)"' % (host, port),
+             trigger='python client.py -a %s -p %s -w "$(pwd)"' % (bind_address, port),
 
              resources=["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/vpn/app/client.py",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/vpn/client/Dockerfile",

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/configurator.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/configurator.py
@@ -5,8 +5,10 @@ import sys
 
 def get_app_request(host, port, service_id, vpn_server_address, vpn_server_port, vpn_address):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
-             trigger= 'mkdir -p keys && python configurator.py -a %s -p %s -w "$(pwd)"/keys/ -s %s -m %s -v %s -o %s' %(host, port, vpn_server_address, vpn_mask, vpn_address, vpn_server_port),
+             trigger= 'mkdir -p keys && python configurator.py -a %s -p %s -w "$(pwd)"/keys/ -s %s -m %s -v %s -o %s' % (bind_address, port, vpn_server_address, vpn_mask, vpn_address, vpn_server_port),
 
              resources = ["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/vpn/app/configurator.py",
                           "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/vpn/easy-rsa/gen_ca.sh",

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/server.py
@@ -2,8 +2,10 @@
 
 def get_server_app_request(host, port, service_id):
 
+    bind_address = "0.0.0.0"
+
     d = dict(service_id=service_id,
-             trigger='python server.py -a %s -p %s -w "$(pwd)"' %(host, port),
+             trigger='python server.py -a %s -p %s -w "$(pwd)"' %(bind_address, port),
              resources=["https://raw.githubusercontent.com/dana-i2cat/cnsmo/master/src/main/python/net/i2cat/cnsmoservices/vpn/app/server.py",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/vpn/server/Dockerfile",
                         "https://raw.githubusercontent.com/dana-i2cat/cnsmo-net-services/master/src/main/docker/vpn/server/tun_manager.sh",],


### PR DESCRIPTION
This patch causes CNSMO network services apps to bind to all local interfaces.

This is achieved by using 0.0.0.0 as the address  to bind to.

Motivation:
In clouds, it is common that VM interfaces don't have the public address they have been assigned, but a private one the cloud network translates to the public one. Due to this fact, trying to bind apps (bind a socket) to the public address fails, as there is no such local address.
Instead of trying to identify which of the local addresses is translated to the public one, this patch binds to all local addresses as a workaround.
