### PR TITLE
Feature/fw port ranges

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
@@ -119,13 +119,19 @@ def is_valid_rule(rule):
     if rule[DEST_SRC] not in ('dst', 'src'):
         return False
 
-    # port is an int between 0 and 65535
-    try:
-        dst_port = int(rule[DST_PORT])
-        if dst_port < 0 or dst_port > 65535:
-            return False
-    except ValueError:
+    # Support port ranges in the form port1:portN
+    dports = rule[DST_PORT].split(":")
+    if len(dports) > 2:
         return False
+
+    for dport in dports:
+        # port is an int between 0 and 65535
+        try:
+            dst_port = int(dport)
+            if dst_port < 0 or dst_port > 65535:
+                return False
+        except ValueError:
+            return False
 
     # ip_range is a valid IP range in CIDR notation (IPv4 or IPv6)
     if not (iptools.ipv4.validate_cidr(rule[IP_RANGE]) or iptools.ipv6.validate_cidr(rule[IP_RANGE])):

--- a/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/app/server.py
@@ -80,10 +80,10 @@ def delete_rule():
 
     rule = json.loads(request.data)
     if not is_valid(rule):
-        return "Invalid rule. Expected format {}".format(RULE_FORMAT), 409
+        return "Invalid rule. Expected format {}".format(RULE_FORMAT), 400
 
     if is_valid_policy(rule):
-        return "Unsupported operation. Cannot delete policy", 400
+        return "Unsupported operation. Cannot delete policy", 409
 
     try:
         command = "docker run -t --rm --net=host --privileged fw-docker"

--- a/src/test/python/cnsmoservices/fw/serverchecker.py
+++ b/src/test/python/cnsmoservices/fw/serverchecker.py
@@ -60,14 +60,14 @@ class FirewallServerAppTest(unittest.TestCase):
             r = requests.post("http://127.0.0.1:9095/fw/", data=bad_rule)
             print r
             print r.content
-            self.assertEquals(409, r.status_code)
+            self.assertEquals(400, r.status_code)
 
         for bad_rule in self.bad_rules:
             print bad_rule
             r = requests.delete("http://127.0.0.1:9095/fw/", data=bad_rule)
             print r
             print r.content
-            self.assertEquals(409, r.status_code)
+            self.assertEquals(400, r.status_code)
 
     def test_removing_existing_rules(self):
 

--- a/src/test/python/cnsmoservices/fw/serverchecker.py
+++ b/src/test/python/cnsmoservices/fw/serverchecker.py
@@ -9,6 +9,7 @@ class FirewallServerAppTest(unittest.TestCase):
     rule1 = '{"direction":"in", "protocol":"tcp", "dst_port":"8080", "dst_src":"src","ip_range":"127.0.0.1/32", "action":"drop"}'
     rule2 = '{"direction":"out", "protocol":"tcp", "dst_port":"8080", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"drop"}'
     rule3 = '{"direction":"in", "protocol":"udp", "dst_port":"8080", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"acpt"}'
+    rule4 = '{"direction":"in", "protocol":"udp", "dst_port":"8080:8090", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"acpt"}'
 
     bad_rule1 = '{"protocol":"tcp", "dst_port":"8080", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"drop"}'
     bad_rule2 = '{"direction":"in", "protocol":"tcp", "dst_port":"9999999", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"drop"}'
@@ -19,7 +20,7 @@ class FirewallServerAppTest(unittest.TestCase):
     bad_rule7 = '{"direction":"in", "protocol":"tcp", "dst_port":"bad_port", "dst_src":"dst", "ip_range":"127.0.0.1/32", "action":"drop"}'
     bad_rule8 = '{"direction":"in", "protocol":"tcp", "dst_port":"8080", "dst_src":"BAD", "ip_range":"127.0.0.1/32", "action":"drop"}'
 
-    good_rules = {rule1, rule2, rule3}
+    good_rules = {rule1, rule2, rule3, rule4}
     bad_rules = {bad_rule1, bad_rule2, bad_rule3, bad_rule4, bad_rule5, bad_rule6, bad_rule7, bad_rule8}
 
     def test_unbuilt_server_does_not_allow_rules_but_build_does(self):


### PR DESCRIPTION
Support rules which use a port range in "dst_port" value, in the form "port1:portN".
These rules match traffic in any of the ports in specified range, both ends included.

An example of a complete rule using this feature:
{"direction":"in", "protocol":"tcp", "dst_port":"8080:8090", "dst_src":"dst", "ip_range":"0.0.0.0/0", "action":"acpt"}
