### PR TITLE
Feature/lb alpine

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/lb/app/configurator.py
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/app/configurator.py
@@ -99,14 +99,13 @@ backend servers
 """
 
 DOCKERFILE_TEMPLATE = """
-FROM ubuntu:14.04
+FROM alpine:3.4
 
-RUN \
-  sed -i 's/^# \(.*-backports\s\)/\\1/g' /etc/apt/sources.list && \
-  apt-get update && \
-  apt-get install -y haproxy python && \
-  sed -i 's/^ENABLED=.*/ENABLED=1/' /etc/default/haproxy && \
-  rm -rf /var/lib/apt/lists/*
+RUN apk add -U \
+    haproxy \
+    python \
+    bash \
+  && rm -rf /var/cache/apk/*
 
 ADD haproxy.cfg /etc/haproxy/haproxy.cfg
 ADD start.bash /haproxy-start

--- a/src/main/python/net/i2cat/cnsmoservices/lb/app/configurator.py
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/app/configurator.py
@@ -74,13 +74,14 @@ defaults
         option redispatch
         retries 3
         maxconn 2000
-        contimeout      5000
-        clitimeout      50000
-        srvtimeout      50000
+        timeout connect      5000
+        timeout client      50000
+        timeout server      50000
 
 frontend lb
         bind 0.0.0.0:{{ port }}
         mode tcp
+        option tcplog
         timeout client 3600s
         default_backend servers
 


### PR DESCRIPTION
Use Linux Alpine 3.4 as base image for LB docker container.

The container uses latest haproxy version for alpine available through apk, which today is haproxy  1.6.6.
This represents a significant update from the previously used in ubuntu (haproxy 1.4.24).
