### PR TITLE
Feature/pre buildable slipstream scripts

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-postinstall.sh
+++ b/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-postinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -35,3 +42,9 @@ echo -e \
   "${PORT}\n${CONFIG_FILE}\n${LOG_FILE}\n${DATA_DIR}\n${EXECUTABLE}\n" | \
   utils/install_server.sh
 cd ..
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -19,3 +26,8 @@ cd ..
 # install cnsmo requirements
 pip install -r cnsmo/cnsmo/requirements.txt
 
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -27,3 +34,9 @@ cd redis-3.0.7
 make
 make install --quiet
 cd ..
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
@@ -33,6 +33,14 @@ rm redis-3.0.7.tar.gz
 cd redis-3.0.7
 make
 make install --quiet
+PORT=20379
+CONFIG_FILE=/etc/redis/20379.conf
+LOG_FILE=/var/log/redis_20379.log
+DATA_DIR=/var/lib/redis/20379
+EXECUTABLE=/usr/local/bin/redis-server
+echo -e \
+  "${PORT}\n${CONFIG_FILE}\n${LOG_FILE}\n${DATA_DIR}\n${EXECUTABLE}\n" | \
+  utils/install_server.sh
 cd ..
 
 # remove persisted network configuration (for compatibility with pre-built images)

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -19,3 +26,8 @@ cd ..
 # install cnsmo requirements
 pip install -r cnsmo/cnsmo/requirements.txt
 
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ]; then
     # install docker
     prinf "installing docker..."
@@ -46,3 +53,10 @@ echo -e \
   utils/install_server.sh
 cd ..
 prinf "installing redis... done!"
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+prinf "Rebooting for kernel upgrade"
+reboot


### PR DESCRIPTION
 Slipstream recipes creating pre-buildable images.

For images to be consistent when pre-built, the following has been applied:
- Set working directory of all recipes to /var/tmp/slipstream (workaround for issue https://github.com/slipstream/SlipStreamClient/issues/301)
- Remove network configuration persisted before the build (end of post-install)
- Reboot  before the build (end of post-install), in order to apply new kernel installed by docker installation script