### PR TITLE
Doc/vpn service deployment

### DIFF
--- a/src/main/python/net/i2cat/cnsmoservices/vpn/README.md
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/README.md
@@ -1,0 +1,61 @@
+# VPN service
+
+The VPN service consists of 4 different components:
+* Orchestrator. Manages in a centralized manner the deployment of the VPN.
+* Configurator. Generates configuration files and key-pairs for server and clients.
+* Server. Configures and deploys an openvpn server.
+* Client. Configures and deploys an openvpn client, bound to the server.
+
+All these components require an extra 5th component:
+* CNSMO systemstate. Used for service discovery.
+
+## How to run
+
+Executable files can be located at:
+* src/main/python/net/i2cat/cnsmoservices/vpn/run directory, for VPN specific components
+* src/main/python/net/i2cat/cnsmo/run/systemstate.py, for the CNSMO systemstate
+
+Requirements:
+* docker (check docker automatic installation instructions for GNU-Linux systems [here](https://docs.docker.com/engine/getstarted/linux_install_help/), or the general [docker installation instructions page](https://docs.docker.com/engine/installation/)).
+* python 2.7.X and pip
+* openvpn (check [openvpn download page](https://openvpn.net/index.php/download/community-downloads.html))
+* redis server installed (check [redis download page](https://redis.io/download))
+* a VM to act as the VPN client
+
+### Run the server
+1. Run the redis server
+2. Keep in mind your IP address (IP_ADDR)
+3. Install the dependencies with: ```sudo pip install -r requirements.txt``` 
+(it is recommended to do this in a  python virtual env)
+4. Run the system state: ```python src/main/python/net/i2cat/cnsmo/run/systemstate.py```
+5. Run the orchestrator: ```python src/main/python/net/i2cat/cnsmoservices/vpn/run/orchestrator.py -r IP_ADDR:6379```.
+It will wait for the rest of services to start the VPN deployment.
+6. Run the configurator: ```sudo python src/main/python/net/i2cat/cnsmoservices/vpn/run/configurator.py -a IP_ADDR -p 9093 -r IP_ADDR:6379 -s VPNConfigurator --vpn-server-ip IP_ADDR --vpn-server-port 1194 --vpn-address 10.10.10.0 --vpn-mask 255.255.255.0```
+7. Run the server: ```sudo python src/main/python/net/i2cat/cnsmoservices/vpn/run/server.py -a IP_ADDR -p 9092 -r IP_ADDR:6379 -s VPNServer```
+
+### Run the client
+8. Start de client VM, bridged to the host (must be able to reach IP_ADDR). Run ```vagrant up``` from ```src/main/python/net/i2cat/cnsmoservices/vpn/run/provision/client/``` directory.
+9. Login to the vm: ```vagrant ssh```
+10. Download CNSMO sources. If using provided Vagrantfile, local sources directory tree is already mounted to ```/cnsmo```.
+11. Install software requirements (redis is not required). ```sudo apt-get install -y curl git cython python-pip```
+12. Install dependencies, as in step 3 for the server.
+13. Keep in mind the client VM IP address (CLIENT_IP_ADDR)
+14. Run the client: ```sudo python src/main/python/net/i2cat/cnsmoservices/vpn/run/client.py -a CLIENT_IP_ADDR -p 9091 -r IP_ADDR:6379 -s VPNClient-1```
+
+###Clean up
+
+```
+# IN CLIENT VM:
+sudo killall python
+sudo rm -rf /home/CNSMO
+sudo docker rm -f client-vpn
+sudo docker rmi client-vpn
+
+# IN SERVER HOST:
+sudo killall python
+sudo rm -rf /home/CNSMO
+sudo docker rm -f server-vpn
+sudo docker rmi vpn-server
+```
+Run ```vagrant destroy``` from ```src/main/python/net/i2cat/cnsmoservices/vpn/run/provision/client/``` directory.
+Also, stop the redis server.

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/provision/client/Vagrantfile
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/provision/client/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Create a network interface bridged to eth0 in the host.
+  config.vm.network "public_network", :bridge => "eth0"
+
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../../../../../../../../../../", "/cnsmo"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
Provide documentation on how to manually create a local deployment of the VPN service, using a Vagrant provisioned VM to run the VPN client.