### PR TITLE
Feature/stop services

### DIFF
--- a/src/main/python/net/i2cat/cnsmo/deployment/bash.py
+++ b/src/main/python/net/i2cat/cnsmo/deployment/bash.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import wget
 import time
+import signal
 
 
 class BashDeployer:
@@ -42,9 +43,8 @@ class BashDeployer:
         print("Stopping app...")
         if instance.get_process() is not None:
             print("Signalling for termination...")
-            instance.get_process().terminate()
-            time.sleep(5)
-            instance.get_process().kill()
+            os.killpg(os.getpgid(instance.get_process().pid), signal.SIGTERM)
+            time.sleep(2)
             instance.set_process(None)
         print("Stopped app")
         return instance
@@ -94,7 +94,7 @@ class BashDeployer:
         :return:
         """
         shell_command = "cd %s && " %working_dir +  command #self.wrap_command(command)
-        process = subprocess.Popen(shell_command, shell=True)
+        process = subprocess.Popen(shell_command, shell=True, preexec_fn=os.setsid)
         return process
 
     def wrap_command(self, command, working_dir):

--- a/src/main/python/net/i2cat/cnsmo/lib/message/serviceshutdown.py
+++ b/src/main/python/net/i2cat/cnsmo/lib/message/serviceshutdown.py
@@ -1,12 +1,12 @@
 from src.main.python.net.i2cat.cnsmo.lib.message.base import Message
 
 
-class NewService(Message):
+class ServiceShutdown(Message):
 
     def __init__(self, service_type=None, service_id=None, service_status=None):
         """
         Most Basic Message exchanged between system state managers and clients.
-        It actually shows that a new service was launched
+        It actually shows that a service was shut down.
 
         :param service_type:
         :param service_id:

--- a/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.sh
+++ b/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-deployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-postinstall.sh
+++ b/src/main/python/net/i2cat/cnsmo/run/slipstream/cnsmo-postinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -35,3 +42,9 @@ echo -e \
   "${PORT}\n${CONFIG_FILE}\n${LOG_FILE}\n${DATA_DIR}\n${EXECUTABLE}\n" | \
   utils/install_server.sh
 cd ..
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmo/system/state/client/systemstate.py
+++ b/src/main/python/net/i2cat/cnsmo/system/state/client/systemstate.py
@@ -1,5 +1,6 @@
 from src.main.python.net.i2cat.cnsmo.lib.model.service import Service
 from src.main.python.net.i2cat.cnsmo.lib.message.newservice import NewService
+from src.main.python.net.i2cat.cnsmo.lib.message.serviceshutdown import ServiceShutdown
 from src.main.python.net.i2cat.cnsmo.service.maker import ServiceMaker
 
 
@@ -45,6 +46,10 @@ class SystemStateClient:
             #self.advertise()
             self.__listener.start()
 
+    def stop(self):
+        # TODO Implement stop properly, as the opposite of start
+        pass
+
     def subscribe_all(self):
         """
         Subscribes all the services
@@ -62,10 +67,17 @@ class SystemStateClient:
 
     def advertise(self):
         """
-        Publishes into the DISCOVERy topic himself
+        Publishes into the DISCOVERY topic himself
         :return:
         """
         self.__publisher.publish(self.DEFAULT_CHANNEL, NewService(*self.__service_data).jsonify())
+
+    def deadvertise(self):
+        """
+        Publishes into the DISCOVERY topic himself is no longer registered
+        :return:
+        """
+        self.__publisher.publish(self.DEFAULT_CHANNEL, ServiceShutdown(*self.__service_data).jsonify())
 
     def callback(self, message):
         """

--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/fw/run/slipstream/fwpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -19,3 +26,8 @@ cd ..
 # install cnsmo requirements
 pip install -r cnsmo/cnsmo/requirements.txt
 
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesclientdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/integrated/run/slipstream/netservicesserverdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratordeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -27,3 +34,9 @@ cd redis-3.0.7
 make
 make install --quiet
 cd ..
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/lb/run/slipstream/lborchestratorpostinstall.sh
@@ -33,6 +33,14 @@ rm redis-3.0.7.tar.gz
 cd redis-3.0.7
 make
 make install --quiet
+PORT=20379
+CONFIG_FILE=/etc/redis/20379.conf
+LOG_FILE=/var/log/redis_20379.log
+DATA_DIR=/var/lib/redis/20379
+EXECUTABLE=/usr/local/bin/redis-server
+echo -e \
+  "${PORT}\n${CONFIG_FILE}\n${LOG_FILE}\n${DATA_DIR}\n${EXECUTABLE}\n" | \
+  utils/install_server.sh
 cd ..
 
 # remove persisted network configuration (for compatibility with pre-built images)

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnclientpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ] ; then
     # install docker
     curl -fsSL https://get.docker.com/ | sh
@@ -19,3 +26,8 @@ cd ..
 # install cnsmo requirements
 pip install -r cnsmo/cnsmo/requirements.txt
 
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+reboot

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+cd ${DIRECTORY}
+
 cwd=${PWD}
 python ${cwd}/cnsmo/cnsmo/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverdeployment.py &
 disown $!

--- a/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverpostinstall.sh
+++ b/src/main/python/net/i2cat/cnsmoservices/vpn/run/slipstream/vpnserverpostinstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# set working directory
+DIRECTORY='/var/tmp/slipstream'
+if [ ! -d "$DIRECTORY" ]; then
+  mkdir -p ${DIRECTORY}
+fi
+cd ${DIRECTORY}
+
 if [ $(docker --version 1>/dev/null 2>/dev/null; echo $?) != "0" ]; then
     # install docker
     prinf "installing docker..."
@@ -46,3 +53,10 @@ echo -e \
   utils/install_server.sh
 cd ..
 prinf "installing redis... done!"
+
+# remove persisted network configuration (for compatibility with pre-built images)
+rm -f /etc/udev/rules.d/*net*.rules
+
+# reboot to apply new kernel, upgraded by docker installation script
+prinf "Rebooting for kernel upgrade"
+reboot

--- a/src/test/python/cnsmoservices/vpn/mock/client.py
+++ b/src/test/python/cnsmoservices/vpn/mock/client.py
@@ -1,12 +1,13 @@
 import getopt
 import os
 import logging
-import shlex
-import subprocess
-
+import signal
+import time
 import sys
+import requests
 from flask import Flask
 from flask import request
+from multiprocessing import Process
 
 log = logging.getLogger('cnsmo.vpn.server.app')
 
@@ -93,6 +94,22 @@ def stop_client():
         return str(e), 409
 
 
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+    return 'App shutting down...', 200
+
+
+def request_app_shutdown(host, port):
+    # As shutdown requires a request context, an http request is required
+    url = "http://%s:%s/shutdown/" % (host, port)
+    requests.post(url)
+
+
 def save_file(file_handler, file_name):
     # filename = secure_filename(file_handler.filename)
     log.debug("saving file to " + app.config['UPLOAD_FOLDER'])
@@ -110,12 +127,51 @@ def prepare_config():
     app.config["service_built"] = False
     app.config["service_running"] = False
 
+
+def main(host, port):
+    signal_flag = SignalFlag()
+    server = Process(target=app.run, args=(host, port, {"debug": True}))
+    server.start()
+    while not signal_flag.signal_received():
+        time.sleep(0.5)
+    print("Terminating...")
+    request_app_shutdown(host, port)
+    server.terminate()
+    server.join(2)
+
+
+class SignalFlag:
+    """
+    A single-use flag for SIGINT and SIGTERM signals.
+    """
+    __signal_received = False
+
+    def __init__(self):
+        """
+        Registers callback for SIGINT and SIGTERM
+        """
+        signal.signal(signal.SIGINT, self.flag_signal)
+        signal.signal(signal.SIGTERM, self.flag_signal)
+
+    def flag_signal(self, signum, frame):
+        """
+        Flags
+        :param signum:
+        :param frame:
+        :return:
+        """
+        self.__signal_received = True
+
+    def signal_received(self):
+        return self.__signal_received
+
+
 if __name__ == "__main__":
 
     opts, _ = getopt.getopt(sys.argv[1:], "a:p:w:", ["working-dir="])
 
     host = "127.0.0.1"
-    port = 9094
+    port = 9092
     for opt, arg in opts:
         if opt in ("-w", "--working-dir"):
             working_dir = arg
@@ -124,7 +180,6 @@ if __name__ == "__main__":
         elif opt == "-p":
             port = int(arg)
 
-
     app.config["UPLOAD_FOLDER"] = working_dir
     prepare_config()
-    app.run(host=host, port=port, debug=True)
+    main(host, port)

--- a/src/test/python/cnsmoservices/vpn/mock/client.py
+++ b/src/test/python/cnsmoservices/vpn/mock/client.py
@@ -94,22 +94,6 @@ def stop_client():
         return str(e), 409
 
 
-@app.route('/shutdown', methods=['POST'])
-def shutdown():
-    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
-    func = request.environ.get('werkzeug.server.shutdown')
-    if func is None:
-        raise RuntimeError('Not running with the Werkzeug Server')
-    func()
-    return 'App shutting down...', 200
-
-
-def request_app_shutdown(host, port):
-    # As shutdown requires a request context, an http request is required
-    url = "http://%s:%s/shutdown/" % (host, port)
-    requests.post(url)
-
-
 def save_file(file_handler, file_name):
     # filename = secure_filename(file_handler.filename)
     log.debug("saving file to " + app.config['UPLOAD_FOLDER'])
@@ -135,7 +119,6 @@ def main(host, port):
     while not signal_flag.signal_received():
         time.sleep(0.5)
     print("Terminating...")
-    request_app_shutdown(host, port)
     server.terminate()
     server.join(2)
 

--- a/src/test/python/cnsmoservices/vpn/mock/configuratorserver.py
+++ b/src/test/python/cnsmoservices/vpn/mock/configuratorserver.py
@@ -1,7 +1,11 @@
 import getopt
-
+import signal
+import time
 import sys
+import requests
 from flask import Flask
+from flask import request
+from multiprocessing import Process
 
 
 app = Flask(__name__)
@@ -65,8 +69,59 @@ def get_server_key():
     return "GotServerKey", 200
 
 
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    func()
+    return 'App shutting down...', 200
+
+
+def request_app_shutdown(host, port):
+    # As shutdown requires a request context, an http request is required
+    url = "http://%s:%s/shutdown/" % (host, port)
+    requests.post(url)
+
+
 def main(host, port):
-    app.run(host, port, debug=False)
+    signal_flag = SignalFlag()
+    server = Process(target=app.run, args=(host, port, {"debug": True}))
+    server.start()
+    while not signal_flag.signal_received():
+        time.sleep(0.5)
+    print("Terminating...")
+    request_app_shutdown(host, port)
+    server.terminate()
+    server.join(2)
+
+
+class SignalFlag:
+    """
+    A single-use flag for SIGINT and SIGTERM signals.
+    """
+    __signal_received = False
+
+    def __init__(self):
+        """
+        Registers callback for SIGINT and SIGTERM
+        """
+        signal.signal(signal.SIGINT, self.flag_signal)
+        signal.signal(signal.SIGTERM, self.flag_signal)
+
+    def flag_signal(self, signum, frame):
+        """
+        Flags
+        :param signum:
+        :param frame:
+        :return:
+        """
+        self.__signal_received = True
+
+    def signal_received(self):
+        return self.__signal_received
+
 
 if __name__ == "__main__":
 
@@ -88,7 +143,6 @@ if __name__ == "__main__":
         elif opt == "-m":
             vpn_mask = arg
         elif opt == "-v":
-            print opt, arg
             vpn_address = arg
         elif opt == "-o":
             vpn_port = arg

--- a/src/test/python/cnsmoservices/vpn/mock/configuratorserver.py
+++ b/src/test/python/cnsmoservices/vpn/mock/configuratorserver.py
@@ -69,22 +69,6 @@ def get_server_key():
     return "GotServerKey", 200
 
 
-@app.route('/shutdown', methods=['POST'])
-def shutdown():
-    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
-    func = request.environ.get('werkzeug.server.shutdown')
-    if func is None:
-        raise RuntimeError('Not running with the Werkzeug Server')
-    func()
-    return 'App shutting down...', 200
-
-
-def request_app_shutdown(host, port):
-    # As shutdown requires a request context, an http request is required
-    url = "http://%s:%s/shutdown/" % (host, port)
-    requests.post(url)
-
-
 def main(host, port):
     signal_flag = SignalFlag()
     server = Process(target=app.run, args=(host, port, {"debug": True}))
@@ -92,7 +76,6 @@ def main(host, port):
     while not signal_flag.signal_received():
         time.sleep(0.5)
     print("Terminating...")
-    request_app_shutdown(host, port)
     server.terminate()
     server.join(2)
 

--- a/src/test/python/cnsmoservices/vpn/mock/server.py
+++ b/src/test/python/cnsmoservices/vpn/mock/server.py
@@ -1,12 +1,13 @@
 import getopt
 import os
 import logging
-import shlex
-import subprocess
-
+import signal
+import time
 import sys
+import requests
 from flask import Flask
 from flask import request
+from multiprocessing import Process
 
 log = logging.getLogger('cnsmo.vpn.server.app')
 
@@ -103,6 +104,22 @@ def stop_server():
         return str(e), 409
 
 
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
+    shutdown_func = request.environ.get('werkzeug.server.shutdown')
+    if shutdown_func is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    shutdown_func()
+    return 'App shutting down...', 200
+
+
+def request_app_shutdown(host, port):
+    # As shutdown requires a request context, an http request is required
+    url = "http://%s:%s/shutdown/" % (host, port)
+    requests.post(url)
+
+
 def save_file(file_handler, file_name):
     # filename = secure_filename(file_handler.filename)
     log.debug("saving file to " + app.config['UPLOAD_FOLDER'])
@@ -120,6 +137,45 @@ def prepare_config():
     app.config["service_built"] = False
     app.config["service_running"] = False
 
+
+def main(host, port):
+    signal_flag = SignalFlag()
+    server = Process(target=app.run, args=(host, port, {"debug": True}))
+    server.start()
+    while not signal_flag.signal_received():
+        time.sleep(0.5)
+    print("Terminating...")
+    request_app_shutdown(host, port)
+    server.terminate()
+    server.join(2)
+
+
+class SignalFlag:
+    """
+    A single-use flag for SIGINT and SIGTERM signals.
+    """
+    __signal_received = False
+
+    def __init__(self):
+        """
+        Registers callback for SIGINT and SIGTERM
+        """
+        signal.signal(signal.SIGINT, self.flag_signal)
+        signal.signal(signal.SIGTERM, self.flag_signal)
+
+    def flag_signal(self, signum, frame):
+        """
+        Flags
+        :param signum:
+        :param frame:
+        :return:
+        """
+        self.__signal_received = True
+
+    def signal_received(self):
+        return self.__signal_received
+
+
 if __name__ == "__main__":
 
     opts, _ = getopt.getopt(sys.argv[1:], "a:p:w:", ["working-dir="])
@@ -136,4 +192,4 @@ if __name__ == "__main__":
 
     app.config["UPLOAD_FOLDER"] = working_dir
     prepare_config()
-    app.run(host=host, port=port, debug=True)
+    main(host, port)

--- a/src/test/python/cnsmoservices/vpn/mock/server.py
+++ b/src/test/python/cnsmoservices/vpn/mock/server.py
@@ -104,22 +104,6 @@ def stop_server():
         return str(e), 409
 
 
-@app.route('/shutdown', methods=['POST'])
-def shutdown():
-    # Hopefully this will only shutdown the server serving this app, but not the rest in the system
-    shutdown_func = request.environ.get('werkzeug.server.shutdown')
-    if shutdown_func is None:
-        raise RuntimeError('Not running with the Werkzeug Server')
-    shutdown_func()
-    return 'App shutting down...', 200
-
-
-def request_app_shutdown(host, port):
-    # As shutdown requires a request context, an http request is required
-    url = "http://%s:%s/shutdown/" % (host, port)
-    requests.post(url)
-
-
 def save_file(file_handler, file_name):
     # filename = secure_filename(file_handler.filename)
     log.debug("saving file to " + app.config['UPLOAD_FOLDER'])
@@ -145,7 +129,6 @@ def main(host, port):
     while not signal_flag.signal_received():
         time.sleep(0.5)
     print("Terminating...")
-    request_app_shutdown(host, port)
     server.terminate()
     server.join(2)
 


### PR DESCRIPTION
Allow CNSMOManager to stop launched services, via BashDeployer.

CNSMOManager now exposes a `stop_service(service_id)` method for doing that.
BashDeployer has a similar method `stop_app` which uses the process id (pid) identified during the app launch to send a SIGTERM to the processes tree generated by the launch.

